### PR TITLE
When using the Google A2A Python SDK (a2a-sdk), JSON-RPC responses th…

### DIFF
--- a/src/a2a/client/client.py
+++ b/src/a2a/client/client.py
@@ -209,8 +209,8 @@ class A2AClient:
         if not request.id:
             request.id = str(uuid4())
 
-        return SendMessageResponse(
-            **await self._send_request(
+        return SendMessageResponse.model_validate(
+            await self._send_request(
                 request.model_dump(mode='json', exclude_none=True),
                 http_kwargs,
             )


### PR DESCRIPTION
…at are defined as Pydantic root models (such as SendMessageResponse) are not parsed correctly. This results in validation errors when the client attempts to deserialize responses from a compliant A2A server.

# Description

Thank you for opening a Pull Request!
Before submitting your PR, there are a few things you can do to make sure it goes smoothly:

- [ ] Follow the [`CONTRIBUTING` Guide](https://github.com/google-a2a/a2a-python/blob/main/CONTRIBUTING.md).
- [ ] Make your Pull Request title in the <https://www.conventionalcommits.org/> specification.
  - Important Prefixes for [release-please](https://github.com/googleapis/release-please):
    - `fix:` which represents bug fixes, and correlates to a [SemVer](https://semver.org/) patch.
    - `feat:` represents a new feature, and correlates to a SemVer minor.
    - `feat!:`, or `fix!:`, `refactor!:`, etc., which represent a breaking change (indicated by the `!`) and will result in a SemVer major.
- [ ] Ensure the tests and linter pass (Run `nox -s format` from the repository root to format)
- [ ] Appropriate docs were updated (if necessary)

Fixes #<issue_number_goes_here> 🦕
